### PR TITLE
Fix compile error CS0165 on Mono

### DIFF
--- a/Scripts/Engines/BulkOrders/SmallTailorBOD.cs
+++ b/Scripts/Engines/BulkOrders/SmallTailorBOD.cs
@@ -64,10 +64,10 @@ namespace Server.Engines.BulkOrders
 		public static SmallTailorBOD CreateRandomFor( Mobile m )
 		{
 			SmallBulkEntry[] entries;
-			bool useMaterials;
+			bool useMaterials = Utility.RandomBool();
 
 			double theirSkill = m.Skills[SkillName.Tailoring].Base;
-			if ( useMaterials = Utility.RandomBool() && theirSkill >= 6.2 ) // Ugly, but the easiest leather BOD is Leather Cap which requires at least 6.2 skill.
+			if ( useMaterials && theirSkill >= 6.2 ) // Ugly, but the easiest leather BOD is Leather Cap which requires at least 6.2 skill.
 				entries = SmallBulkEntry.TailorLeather;
 			else
 				entries = SmallBulkEntry.TailorCloth;


### PR DESCRIPTION
When running on mono building scripts, it will yield

Errors:
- Engines/BulkOrders/SmallTailorBOD.cs:
   CS0165: Line 88: Use of unassigned local variable `useMaterials'

Calling RandomBool out of if
