### PR TITLE
Infinite Loop Breakout

### DIFF
--- a/Scripts/Items/Skill Items/Tools/BaseRunicTool.cs
+++ b/Scripts/Items/Skill Items/Tools/BaseRunicTool.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 
 namespace Server.Items
 {
@@ -180,7 +181,7 @@ namespace Server.Items
 
 		private static void ApplySkillBonus( AosSkillBonuses attrs, int min, int max, int index, int low, int high )
 		{
-			SkillName[] possibleSkills = ( attrs.Owner is Spellbook ? m_PossibleSpellbookSkills : m_PossibleBonusSkills );
+			List<SkillName> possibleSkills = new List<SkillName>( attrs.Owner is Spellbook ? m_PossibleSpellbookSkills : m_PossibleBonusSkills );
 			int count = ( Core.SE ? possibleSkills.Length : possibleSkills.Length - 2 );
 
 			SkillName sk, check;
@@ -190,11 +191,12 @@ namespace Server.Items
 			do
 			{
 				found = false;
-				sk = possibleSkills[Utility.Random( count )];
+				sk = possibleSkills[Utility.Random( count-- )];
+				possibleSkills.Remove(sk);
 
 				for ( int i = 0; !found && i < 5; ++i )
 					found = ( attrs.GetValues( i, out check, out bonus ) && check == sk );
-			} while ( found );
+			} while ( found && count > 0 );
 
 			attrs.SetValues( index, sk, Scale( min, max, low, high ) );
 		}


### PR DESCRIPTION
There is a very rare potential, mostly in custom situations, for the 'BaseRunicTool' 'ApplySkillBonus' method to cause the server to become unresponsive.
The reason for this is that, if you call the method on a 'Spellbook' which already has all 4 of the skills listed by default in 'm_PossibleSpellbookSkills', then 'found' is always true.

This issue has been reproduced on a shard that calls 'ApplySkillBonus' more than once when crafting 'Spellbooks'; the rarity is that the 'ApplyAttributesTo' method may call the 'ApplySkillBonus' more than once; the off-chance of 5 consecutive calls, where each preceding call applies one unique skill of the 'possibleSkills', would result in the 5th call entering the deadlock state.

The fix is quite simple, evaluate the 'count' in the while statement and decrement it for each skill that is checked; removing each skill from the 'possibleSkills' list as they are checked, to prevent them being checked multiple times due to the random indices selection.