### PR TITLE
Housekeeping

### DIFF
--- a/Server/Map.cs
+++ b/Server/Map.cs
@@ -61,7 +61,7 @@
  *	This update generally increases performance and reduces overall player
  *	connection latency.
  */
-//#define Map_NewEnumerables
+#define Map_NewEnumerables
 
 /*
  * UseMaxRange


### PR DESCRIPTION
+ Core housekeeping, converted some for-loops to foreach-loops.

+ Reimplementation of Core.TickCount using only native .NET Stopwatch.
* Stopwatch actually wraps the QueryPerformanceCounter method to get its result and can also be used to determine whether HRT is supported.
- Removed SafeNativeMethods DLLImport for QueryPerformanceCounter.

+ Added Core.GlobalUpdateRange to define a constant standard range used in many calculations throughout RunUO.
* The value '18' in a range context is hard-coded in many places, this new property will eventually be used to replace those usages.