### PR TITLE
Incorrect parameters for mono

### DIFF
--- a/Server/ScriptCompiler.cs
+++ b/Server/ScriptCompiler.cs
@@ -231,12 +231,11 @@ namespace Server
 				if( Core.HaltOnWarning )
 					parms.WarningLevel = 4;
 
-#if !MONO
-				CompilerResults results = provider.CompileAssemblyFromFile( parms, files );
-#else
+#if MONO
 				parms.CompilerOptions = String.Format( "{0} /nowarn:169,219,414 /recurse:Scripts/*.cs", parms.CompilerOptions );
-				CompilerResults results = provider.CompileAssemblyFromFile( parms, "" );
 #endif
+				CompilerResults results = provider.CompileAssemblyFromFile( parms, files );
+				
 				m_AdditionalReferences.Add( path );
 
 				Display( results );


### PR DESCRIPTION
The second parameter CompileAssemblyFromFile was incorrect for mono. The expected settings are the same as for the Windows compiler. 
So I extracted this identical portion of code. 

Unfortunately I could not test on Windows.

Works with:
Centos
Mono JIT compiler version 5.8.0.0.127 (tarball Wed Feb 21 04:20:57 UTC 2018)
