### PR TITLE
Reimplement Main Loop and Timer System

### DIFF
--- a/Scripts/Engines/Factions/Mobiles/Guards/GuardAI.cs
+++ b/Scripts/Engines/Factions/Mobiles/Guards/GuardAI.cs
@@ -143,7 +143,7 @@ namespace Server.Factions
 				if ( m_Bandage == null )
 					return TimeSpan.MaxValue;
 
-				TimeSpan ts = ( m_BandageStart + m_Bandage.Timer.Delay ) - DateTime.UtcNow;
+				TimeSpan ts = m_Bandage.Timer.Remaining;
 
 				if ( ts < TimeSpan.FromSeconds( -1.0 ) )
 				{

--- a/Scripts/Engines/Khaldun/RaiseSwitch.cs
+++ b/Scripts/Engines/Khaldun/RaiseSwitch.cs
@@ -105,8 +105,6 @@ namespace Server.Items
 			public ResetTimer( RaiseSwitch raiseSwitch, TimeSpan delay ) : base( delay )
 			{
 				m_RaiseSwitch = raiseSwitch;
-
-				Priority = ComputePriority( delay );
 			}
 
 			protected override void OnTick()

--- a/Scripts/Gumps/AdminGump.cs
+++ b/Scripts/Gumps/AdminGump.cs
@@ -288,9 +288,11 @@ namespace Server.Gumps
 				}
 				case AdminGumpPage.Information_Perf:
 				{
+					/*
 					AddLabel( 20, 130, LabelHue, "Cycles Per Second:" );
 					AddLabel( 40, 150, LabelHue, "Current: " + Core.CyclesPerSecond.ToString( "N2" ) );
 					AddLabel( 40, 170, LabelHue, "Average: " + Core.AverageCPS.ToString( "N2" ) );
+					*/
 
 					StringBuilder sb = new StringBuilder();
 

--- a/Scripts/Mobiles/Vendors/PlayerVendor.cs
+++ b/Scripts/Mobiles/Vendors/PlayerVendor.cs
@@ -1390,7 +1390,7 @@ namespace Server.Mobiles
 
 			protected override void OnTick()
 			{
-				m_Vendor.m_NextPayTime = DateTime.UtcNow + this.Interval;
+				m_Vendor.m_NextPayTime = DateTime.UtcNow + GetInterval();
 
 				int pay;
 				int totalGold;

--- a/Scripts/Spells/Necromancy/PainSpike.cs
+++ b/Scripts/Spells/Necromancy/PainSpike.cs
@@ -64,9 +64,10 @@ namespace Server.Spells.Necromancy
 
 					if( t != null )
 					{
-						t.Delay += TimeSpan.FromSeconds( 2.0 );
-
-						buffTime = t.Next - DateTime.UtcNow;
+						t.Stop();
+						t.Delay = t.Remaining + TimeSpan.FromSeconds( 2.0 );
+						t.Start();
+						buffTime = t.Remaining;
 					}
 				}
 				else

--- a/Server/Item.cs
+++ b/Server/Item.cs
@@ -3045,8 +3045,6 @@ namespace Server
 					m_DeltaQueue.Add(this);
 				}
 			}
-
-			Core.Set();
 		}
 
 		public void RemDelta( ItemDelta flags )

--- a/Server/Main.cs
+++ b/Server/Main.cs
@@ -138,9 +138,7 @@ namespace Server
 		 * system reboot. */
 		public static long Now { get { return m_Now; } }
 
-		private static readonly double _MillisecondsPerTick = 1000.0 / Stopwatch.Frequency;
-
-		public static long TickCount { get { return (long)(Stopwatch.GetTimestamp() * _MillisecondsPerTick); } }
+		public static long TickCount { get { return (long)(Now * MILLISECONDS_PER_ENGINE_TICK); } }
 
 		public static readonly bool Is64Bit = Environment.Is64BitProcess;
 

--- a/Server/Main.cs
+++ b/Server/Main.cs
@@ -38,7 +38,6 @@ namespace Server
 	public static class Core
 	{
 		private static bool m_Crashed;
-		private static Thread timerThread;
 		private static string m_BaseDirectory;
 		private static string m_ExePath;
 
@@ -374,8 +373,6 @@ namespace Server
 			if( !m_Crashed )
 				EventSink.InvokeShutdown( new ShutdownEventArgs() );
 
-			Timer.TimerThread.Set();
-
 			Console.WriteLine( "done" );
 		}
 
@@ -427,12 +424,6 @@ namespace Server
 
 			if( BaseDirectory.Length > 0 )
 				Directory.SetCurrentDirectory( BaseDirectory );
-
-			Timer.TimerThread ttObj = new Timer.TimerThread();
-			timerThread = new Thread(ttObj.TimerMain)
-			{
-				Name = "Timer Thread"
-			};
 
 			Version ver = m_Assembly.GetName().Version;
 
@@ -489,8 +480,6 @@ namespace Server
 			ScriptCompiler.Invoke( "Initialize" );
 
 			m_MessagePump = new MessagePump();
-
-			timerThread.Start();
 
 			foreach (Map m in Map.AllMaps)
 				m.Tiles.Force();

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -9971,8 +9971,6 @@ namespace Server
 					m_DeltaQueue.Enqueue( this );
 				}
 			}
-
-			Core.Set();
 		}
 
 		private bool m_NoMoveHS;

--- a/Server/Network/Listener.cs
+++ b/Server/Network/Listener.cs
@@ -233,8 +233,6 @@ namespace Server.Network
 			lock ( m_AcceptedSyncRoot ) {
 				m_Accepted.Enqueue( socket );
 			}
-
-			Core.Set();
 		}
 
 		private void Release( Socket socket ) {

--- a/Server/Network/MessagePump.cs
+++ b/Server/Network/MessagePump.cs
@@ -104,8 +104,6 @@ namespace Server.Network
 		{
 			lock ( this )
 				m_Queue.Enqueue( ns );
-
-			Core.Set();
 		}
 
 		public void Slice()

--- a/Server/Network/Packets.cs
+++ b/Server/Network/Packets.cs
@@ -4639,8 +4639,6 @@ namespace Server.Network
 
 		public void OnSend()
 		{
-			Core.Set();
-
 			lock (this) {
 				if ((m_State & (State.Acquired | State.Static)) == 0)
 					Free();

--- a/Server/Timer.cs
+++ b/Server/Timer.cs
@@ -309,7 +309,6 @@ namespace Server
 			{
 				long now;
 				int i, j;
-				bool loaded;
 
 				while ( !Core.Closing )
 				{
@@ -320,8 +319,6 @@ namespace Server
 					}
 
 					ProcessChanged();
-
-					loaded = false;
 
 					for ( i = 0; i < m_Timers.Length; i++)
 					{
@@ -341,8 +338,6 @@ namespace Server
 
 								lock ( m_Queue )
 									m_Queue.Enqueue( t );
-
-								loaded = true;
 									
 								if ( t.m_Count != 0 && (++t.m_Index >= t.m_Count) )
 								{
@@ -355,9 +350,6 @@ namespace Server
 							}
 						}
 					}
-
-					if ( loaded )
-						Core.Set();
 
 					m_Signal.WaitOne(1, false);
 				}


### PR DESCRIPTION
The following is a series of commits intended to greatly improve the performance of RunUO. As a bit of background, RunUO consists of a single "main" thread that processes all of the game logic continually in a loop, plus a number of other peripheral threads that handle I/O and timers. The main game engine loop, located in Core.Main() previously ran as fast as it could. On each iteration through the loop, it would check if one of the other peripheral threads had set a signal, implemented as a semaphore. If the signal had not been set (because no packets arrived and no timers expired), the main loop would block and go to sleep to save CPU cycles.

The first patch simplifies the code that obtains the current time. The simplifications can be made purely because in 2018, all available operating systems and platforms have good timing mechanisms now.

The second patch both removes the signal semaphore (which is expensive to use because it requires both syscalls and atomic or locking operations internally) and changes the loop to attempt to run at a fixed rate, referred to as the tick rate. The tick rate is the maximum rate at which the server will advance time, and currently is set to 40Hz (25ms per tick). If the loop completes in less than 25ms, the main thread will go to sleep for the remainder of the time. Some intelligence as to how long and when to go to sleep could be added in the future, but for now the thread sleeps for half of a tick. This effectively trades a syscall/atomic on every iteration (checking the signal) for a syscall only when the thread is ahead of schedule (the call to sleep). Tests show that at 40Hz, there is effectively no CPU usage difference on a near-idle server from the previous implementation. On heavily loaded servers, this should be a significant performance improvement. 

The third patch takes advantage of the constant tick rate by redefining how time is kept in RunUO. Now, everything that occurs within the same tick is considered to be simultaneous. At the beginning of each tick, the time is obtained and cached. All operations during the tick use the cached value. This avoids constantly asking for the current time, which is very expensive. This should also be a large performance improvement.

The final patch in the series re-implements the timer subsystem entirely. It uses a hierarchical time wheel as the base data structure, which makes it very cheap to process timers. It makes it so cheap, in fact, that it no longer makes sense to offload timer processing to a separate thread and they're just handled inline on the main thread.